### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
         "torch",
         "torchvision",
         "torchaudio",
-        "pytorch_lightning",
+        "pytorch_lightning==1.8.3",
         "tqdm",
         "numpy==1.26.0",
         "matplotlib",


### PR DESCRIPTION
adding package version for pytorch-lightning in setup, default 2.4.0; but required old version 1.8.3 for working with old collab books